### PR TITLE
v0.0.5 : nouvelles directives `pushformat` et `popformat`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [0.0.5]
+
+- Ajout des directives `pushformat` et `popformat` pour mémoriser et restituer un format. Voir la documentation de la format de sortie
+pour plus de précisions.
+
 ## [0.0.4]
 
 - Correction d'une anomalie dans la génération du formulaire quand on faisait appel à un squelette par include et que ce

--- a/README.md
+++ b/README.md
@@ -347,6 +347,11 @@ Chaque ligne produite par le squelette est inscrite dans le champ représenté p
     formattage : ________________________________________________ :
  
 La directive prend effet pour toutes les lignes produites après elle et jusqu'à la fin du squelette ou jusqu'à la directive `format` suivante.
+
+Deux directives complémentaires ont été définies pour mémoriser le format courant puis le récupérer plus tard. La mémorisation se fait par la
+directive `pushformat` et la récupération par la directive `popformat`. Attention à ne pas boucler de façon non contrôlé sur la directive
+`pushformat` afin de ne pas provoquer un débordement de pile. L'intérêt de ces directives est de permettre de récupérer un format précédent
+sans le connaître. Ceci peut arriver si on fait appel par include à un squelette qui doit modifier le format provisoirement.
  
 ### 🡆 Définition et utilisation de modèles
 

--- a/resources/skeleton/issue#1-1.skl
+++ b/resources/skeleton/issue#1-1.skl
@@ -1,0 +1,20 @@
+# skodgee
+    { 
+        "name": "Issue#1-1",
+        "description": "Modifier provisoirement le format de sortie",
+        "author": "herve.heritier",
+        "version": "0.0.0",
+        "hidden": "",
+        "prefix": "#" 
+    }
+# end
+# declare
+# end
+# model modelA
+# pushformat
+# format
+:: _______________________________________________________________ ::
+Ce texte provient du modèle nommé modelA du squelette issue#1-1.skl
+Et cette ligne de texte aussi, mais c'est la dernière de ce modèle.
+# popformat
+# endmodel

--- a/resources/skeleton/issue#1.skl
+++ b/resources/skeleton/issue#1.skl
@@ -1,0 +1,43 @@
+# skodgee
+    { 
+        "name": "Issue#1",
+        "description": "Modifier provisoirement le format de sortie",
+        "author": "herve.heritier",
+        "version": "0.0.0",
+        "prefix": "#" 
+    }
+# end
+# declare
+    { "var":"A" },
+    { "grp":"G", "include":"issue#1-1.skl" }
+# end
+# include {{G}}
+         1         2         3         4         5        6          7         8
+12354678901235467890123546789012354678901235467890123546789012354678901235467890
+          
+Le contenu de ce squelette est défini sur une largeur de 80 caractères.
+On va appliquer dessus une directive format qui va en modifier l'aspect à partir
+des lignes suivantes qui contiennent toutes 80 caractères dans le squelette. Et
+on appelle au milieu de tout ça un modèle d'un autre squelette qui utilise un
+autre format et ignore le format utilisé dans l'appelant. Quand on sort de
+ce modèle, on a quand même un retour au bon format, parce qu'il utilise des
+directives pushformat et popformat qui permettent de mémoriser puis de restituer
+le format précédant (voir cela dans le squelette issue#1-1.skl)
+
+# format
+              _________________________________________________
+12354678901235467890123546789012354678901235467890123546789012354678901235467890
+12354678901235467890123546789012354678901235467890123546789012354678901235467890
+12354678901235467890123546789012354678901235467890123546789012354678901235467890
+# format
+    >>> _____________________________________________________________ <<<
+12354678901235467890123546789012354678901235467890123546789012354678901235467890
+12354678901235467890123546789012354678901235467890123546789012354678901235467890
+# usemodel modelA
+12354678901235467890123546789012354678901235467890123546789012354678901235467890
+12354678901235467890123546789012354678901235467890123546789012354678901235467890
+12354678901235467890123546789012354678901235467890123546789012354678901235467890
+# format
+________________________________________________________________________________
+12354678901235467890123546789012354678901235467890123546789012354678901235467890
+12354678901235467890123546789012354678901235467890123546789012354678901235467890


### PR DESCRIPTION
Répond au besoin de l'issue#1
Ajout des directives `pushformat` et `popformat` pour mémoriser et restituer un format. Voir la documentation de la format de sortie pour plus de précisions.