### PR TITLE
v0.0.6 : nouvelle directive `defstr`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [0.0.6]
+
+- Nouvelle directive `defstr` pour définir une variable de stype chaine de caractère.
+
 ## [0.0.5]
 
 - Ajout des directives `pushformat` et `popformat` pour mémoriser et restituer un format. Voir la documentation de la format de sortie

--- a/README.md
+++ b/README.md
@@ -374,13 +374,27 @@ L'utilisation d'une directive `usemodel` dans une directive `model` est sans eff
  
 > Si un modèle provient d'un squelette appelé par `include`, et de ce modèle fait référence à des variables définie dans ce squelette, alors il faut inclure la directive `usemodel` dans une directive `path` qui pointe sur le groupe défini pour l'appel de l'include.
  
+### 🡆 Variable de type chaine de caractère
+
+La directive `defstr` permet de définir une variable de travail alphanumérique.
+
+    # defnum variableDeTravail valeur
+
+Le nom de la variable de travail est libre et sa valeur initiale est donnée par la totalité des caractères qui suivent, incluant même
+les espaces jusqu'à la fin de ligne. On peut composer la valeur en appelant d'autres variables. 
+
+Pour utiliser la variable de travail on doit systématiquement la faire précéder d'un double underscore `{{__variableDeTravail}}`.
+
+Quand on utilise la directive `if` avec une variable définie par la directive `defstr` pour la comparer à une chaine de caractère, alors
+il faut encadrer la chaine de caractère avec des simples quotes (apos), sinon le résultat de la comparaison ne sera pas prévisible.
+
 ### 🡆 Opérations numériques
 
 La directive `defnum` permet de déclarer une variable de travail numérique.
  
     # defnum variableDeTravail formule
  
-La nom de la variable de travail est libre et sa valeur initiale est donnée par la formule qui la suit. Cette formule doit être exprimée en notation arithmétique avec la possibilité d'utiliser dans la formule toutes les variables nécessaires, celles-ci pouvant être soient des variable déclarées au dictionnaire, soient des variables de tavail ou des variables techniques, c'est à dire des variables issues de l'application de toute autre directive précédente ; elles devront également être numériquement valides au moment de l'application de la déclaration.
+Le nom de la variable de travail est libre et sa valeur initiale est donnée par la formule qui la suit. Cette formule doit être exprimée en notation arithmétique avec la possibilité d'utiliser dans la formule toutes les variables nécessaires, celles-ci pouvant être soient des variable déclarées au dictionnaire, soient des variables de tavail ou des variables techniques, c'est à dire des variables issues de l'application de toute autre directive précédente ; elles devront également être numériquement valides au moment de l'application de la déclaration.
  
 La variable de travail est valide à partir de la directive `defnum` et ne peut-être déclarée à nouveau dans la suite du squelette. 
  

--- a/resources/skeleton/issue#2.skl
+++ b/resources/skeleton/issue#2.skl
@@ -1,0 +1,33 @@
+# skodgee
+    { 
+        "name": "Issue#2",
+        "description": "Définir et utiliser une variable de type string",
+        "author": "herve.heritier",
+        "version": "0.0.0",
+        "prefix": "#" 
+    }
+# end
+# declare
+    { "var":"A" }
+# end
+A = {{A}}
+# defstr B blabla
+B = {{__B}}
+# if {{__B}} = blabla
+oui B est pas égale à blabla
+# endif
+# if {{__B}} = 'blabla'
+oui B est égale à 'blabla'
+# endif
+# if {{__B}} # blabla
+mais B n'est pas égale à blabla
+# endif
+# if {{__B}} # 'blabla'
+mais B n'est pas égale à 'blabla'
+# endif
+# if {{__B}} = {{A}}
+B est égale à A
+# endif
+# if {{__B}} # {{A}}
+B n'est pas égale à A
+# endif

--- a/src/skeleton.ts
+++ b/src/skeleton.ts
@@ -92,6 +92,7 @@ const RGXendpath = new RegExp(prefix.concat('\\s*(endpath)\\s*$'))
 const RGXendmodel = new RegExp(prefix.concat('\\s*(endmodel)\\s*$'))
 const RGXusemodel = new RegExp(prefix.concat('\\s*(usemodel)\\s+(\\w+)'))
 const RGXdefnum = new RegExp(prefix.concat('\\s*(defnum)\\s+(\\w+)\\s+(.+)'))
+const RGXdefstr = new RegExp(prefix.concat('\\s*(defstr)\\s+(\\w+)\\s+(.+)'))
 const RGXcalc = new RegExp(prefix.concat('\\s*(calc)\\s+(\\w+)\\s+(.+)'))
 const RGXapostString = /^'(.*)'$/
 const RGXquotedString = /^"(.*)"$/
@@ -459,6 +460,26 @@ export function resolveSkeleton(skeletonName:string,source:any,vars:valorizedDic
             }
             let value = eval(rl)
             localVariables.push({name:searchDefine[2],value:value})
+            sourceIndex++
+            continue exploration
+        }
+
+        // directive defstr
+        let searchDefstr = RGXdefstr.exec(line)
+        if(searchDefstr!==null) {
+            let lv = localVariables.find(e=>{ return searchDefstr!==null ? e.name===searchDefstr[2] : false })
+            if(lv!==undefined) {
+                throw(''.concat(
+                    `La génération du code a échoué`,
+                    `\nla variable locale "${searchDefstr[2]}" a été redéfinie à tort, elle existait déjà`,
+                    `\nen ligne ${sourceIndex+1} du squelette "${skeletonName}"`,
+                    `\n==> ligne          :\n${line}\n`,
+                    `\n==> localVariables :\n${JSON.stringify(vars,null,4)}`
+                ))
+            }
+            let rl = resolveLine(searchDefstr[3],vars,forStack,activePath,sourceIndex,skeletonName)
+            let value = rl
+            localVariables.push({name:searchDefstr[2],value:value})
             sourceIndex++
             continue exploration
         }


### PR DESCRIPTION
Comme demandé dans l'issue#2, mise à disposition d'une nouvelle directive pour créer des variables de travail de type chaine de caractère