### PR TITLE
v0.0.8 : résolution de variables à tort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [0.0.8]
+
+- Il n'est plus tenté de résoudre à tort des variables appelées dans les directives repeat 
+non vérifiées (repeat contenu dans if sur condition fausse, dans for sur groupe vide, dans un repeat zéro) 
+ce qui pouvait provoquer des erreurs de génération.
+
 ## [0.0.7]
 
 - Correction pour voir les groupes vides après une injection qui n'étaient pas visibles, donc pour lesquelles il était

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "SKODGEE",
   "description": "SKodgee Obviously Designed for Generation Enhanced Efficiently",
   "publisher": "skodgeeTeam",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "engines": {
     "vscode": "^1.46.0"
   },

--- a/resources/skeleton/repeatInValidOrInvalidIfOrFor.skl
+++ b/resources/skeleton/repeatInValidOrInvalidIfOrFor.skl
@@ -1,0 +1,31 @@
+# skodgee
+    { 
+        "name": "Repeat dans un if",
+        "description": "repeat into if",
+        "author": "herve.heritier",
+        "version": "0.0.0",
+        "prefix": "#" 
+    }
+# end
+# declare
+    { "var":"A", "lib":"variable A" },
+    { "var":"B", "lib":"variable B" }
+# end
+Quelles valeurs A et B doivent prendre pour
+qu'il n'y ai aucune erreur 
+et que la valeur de toto soit affichée ?
+# if {{A}} = {{B}}
+#   defnum zorro {{B}}
+#   repeat {{A}}
+#     defnum toto {{A}}
+#     repeat {{__zorro}}
+
+#     endrepeat
+#   endrepeat
+# endif
+
+Que vaut toto ?
+
+toto = {{__toto}}
+
+c'est un succès !!!

--- a/src/skeleton.ts
+++ b/src/skeleton.ts
@@ -264,7 +264,7 @@ export function resolveSkeleton(skeletonName:string,source:any,vars:valorizedDic
         // début d'un repeat numérique ?
         let searchRepeatInteger = RGXrepeatInteger.exec(line)
         if(searchRepeatInteger!==null) {
-            repeatStack.push({ indice:1, max:parseInt(searchRepeatInteger[2]), sourceIndex:sourceIndex })
+            repeatStack.push({ indice:1, max: processNext===true ? parseInt(searchRepeatInteger[2]) : 0, sourceIndex:sourceIndex })
             sourceIndex++
             continue exploration
         }
@@ -272,12 +272,16 @@ export function resolveSkeleton(skeletonName:string,source:any,vars:valorizedDic
         // début d'un repeat variable ?
         let searchRepeat = RGXrepeat.exec(line)
         if(searchRepeat!==null) {
-            let rsi = repeatSolve(searchRepeat[2],vars,forStack)
             let max = 0
-            if(rsi!==undefined) {
-                if(!isNaN(rsi.value) && rsi.value!='') max = parseInt(rsi.value)
+            // ne pas calculer rsi si on est dans un if ou un for ou un repeat inactif
+            // pour 1) ne pas planter et 2) avoir un max à zéro
+            if(processNext===true) {
+                let rsi = repeatSolve(searchRepeat[2],vars,forStack)
+                if(rsi!==undefined) {
+                    if(!isNaN(rsi.value) && rsi.value!='') max = parseInt(rsi.value)
+                }
             }
-            repeatStack.push({ indice:1, max:max, sourceIndex:sourceIndex })
+            repeatStack.push({ indice:1, max: max, sourceIndex:sourceIndex })
             sourceIndex++
             continue exploration
         }


### PR DESCRIPTION
Il n'est plus tenté de résoudre à tort des variables appelées dans les directives repeat non vérifiées (repeat contenu dans un if sur condition fausse, dans un for sur groupe vide, dans un repeat à zéro) ce qui pouvait provoquer des erreurs de génération.