### PR TITLE
V0.0.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 vsc-extension-quickstart.md
 out
 resources/skeleton/cine.txt
+resources/doNotExport

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Plus de plantage sur la directive if quand on tentait de tester la variable d'indice de la directive for qui la précédait
 immédiatement alors que le groupe pointé par la directive for n'avait pas d'occurrence.
 - Tout plantage lors de la génération retourne désormais le numéro et le contenu de la ligne qui provoque l'erreur.
+- La directive `calc` est maintenant utilisable sur les variables de travail déclarée par la directive `defstr`.
 
 ## [0.0.9]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## [0.0.10] - 2021-05-10
+
+- Plus de plantage sur la directive if quand on tentait de tester la variable d'indice de la directive for qui la précédait
+immédiatement alors que le groupe pointé par la directive for n'avait pas d'occurrence.
+- Tout plantage lors de la génération retourne désormais le numéro et le contenu de la ligne qui provoque l'erreur.
+
+## [0.0.9]
+
+- Pour les variables avec une liste de valeurs, la liste filtrante a été remplacé par une liste classique, ce qui permet
+d'avoir la visibilité sur toutes les valeurs possibles.
+- Les boutons "Générer le code" et "Récupérer le code généré" on été déplacé en haut du formulaire.
+
 ## [0.0.8]
 
 - Il n'est plus tenté de résoudre à tort des variables appelées dans les directives repeat 

--- a/README.md
+++ b/README.md
@@ -381,7 +381,17 @@ La directive `defstr` permet de définir une variable de travail alphanumérique
     # defstr variableDeTravail valeur
 
 Le nom de la variable de travail est libre et sa valeur initiale est donnée par la totalité des caractères qui suivent, incluant même
-les espaces jusqu'à la fin de ligne. On peut composer la valeur en appelant d'autres variables. 
+les espaces jusqu'à la fin de ligne. On peut composer la valeur en appelant d'autres variables.
+
+Si lors de la génération une directive `defstr` est rencontrée plus d'une fois pour déclarer une même variable de travail, alors la génération 
+est stoppée en erreur. On s'interdira donc d'utiliser une directive `defstr` dans une répétition ou une boucle.
+
+La directive `calc` permet d'affecter une nouvelle valeur à la variable déclarée par `defstr`.
+ 
+    # calc variableDeTravail formule
+ 
+La formule suit les mêmes règles que pour la directive `defnum`. Il est aussi possible d'utiliser 
+la variable de travail elle-même dans la formule de calcul. Le résultat est une concaténation de toutes les données qui composent la formule.
 
 Pour utiliser la variable de travail on doit systématiquement la faire précéder d'un double underscore `{{__variableDeTravail}}`.
 
@@ -394,7 +404,14 @@ La directive `defnum` permet de déclarer une variable de travail numérique.
  
     # defnum variableDeTravail formule
  
-Le nom de la variable de travail est libre et sa valeur initiale est donnée par la formule qui la suit. Cette formule doit être exprimée en notation arithmétique avec la possibilité d'utiliser dans la formule toutes les variables nécessaires, celles-ci pouvant être soient des variable déclarées au dictionnaire, soient des variables de tavail ou des variables techniques, c'est à dire des variables issues de l'application de toute autre directive précédente ; elles devront également être numériquement valides au moment de l'application de la déclaration.
+Le nom de la variable de travail est libre et sa valeur initiale est donnée par la formule qui la suit.
+Cette formule doit être exprimée en notation arithmétique avec la possibilité d'utiliser dans la formule
+toutes les variables nécessaires, celles-ci pouvant être soient des variable déclarées au dictionnaire,
+soient des variables de tavail ou des variables techniques, c'est à dire des variables issues de l'application 
+de toute autre directive précédente ; elles devront également être numériquement valides au moment de l'application de la déclaration.
+
+Si lors de la génération une directive `defnum` est rencontrée plus d'une fois pour déclarer une même variable de travail, alors la génération 
+est stoppée en erreur. On s'interdira donc d'utiliser une directive `defstr` dans une répétition ou une boucle.
  
 La variable de travail est valide à partir de la directive `defnum` et ne peut-être déclarée à nouveau dans la suite du squelette. 
  
@@ -404,4 +421,7 @@ La directive `calc` permet faire des opérations sur une variable déclarée par
  
 La formule suit les mêmes règles que pour la directive `defnum`. Il est aussi possible d'utiliser la variable de travail elle-même dans la formule de calcul.
  
-Pour utiliser un variable de travail on la fait systématiquement précéder d'un double underscore `{{__variableDeTravail}}` ; bien que le double underscore soit déjà utilisé pour les variables techniques de boucles et de répétition quand elle sont préfixées par un chemin, cette notation est ici non ambiguë puisqu'une variable de travail n'est jamais évaluée dans un chemin, sa portée étant valide depuis sa déclaration et jusqu'à la fin du squelette. 
+Pour utiliser un variable de travail on la fait systématiquement précéder d'un double underscore `{{__variableDeTravail}}` ; 
+bien que le double underscore soit déjà utilisé pour les variables techniques de boucles et 
+de répétition quand elle sont préfixées par un chemin, cette notation est ici non ambiguë puisqu'une
+ variable de travail n'est jamais évaluée dans un chemin, sa portée étant valide depuis sa déclaration et jusqu'à la fin du squelette. 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "SKODGEE",
   "description": "SKodgee Obviously Designed for Generation Enhanced Efficiently",
   "publisher": "skodgeeTeam",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "engines": {
     "vscode": "^1.46.0"
   },

--- a/resources/skeleton/issue#13.skl
+++ b/resources/skeleton/issue#13.skl
@@ -1,0 +1,29 @@
+# skodgee
+    { 
+        "name": "Issue#13",
+        "description": "plantage lors de l'utilisation d'un indice de groupe dans un groupe sans occurrence",
+        "author": "herve.heritier",
+        "version": "0.0.0",
+        "prefix": "#" 
+    }
+# end
+# declare
+    { 
+        "grp": "G1", 
+        "lib":"groupe G1",
+        "rpt":"0,5",
+        "cmp": [
+            { "var":"A", "lib":"variable A" },
+            { "var":"B", "lib":"variable B" }
+        ] 
+    }
+# end
+Avant correction de ce bug, on avait une erreur
+quand on supprimait groupe G1 avant de 
+lancer la génération.
+Maintenant ça ne plante plus !
+# for {{G1}}
+#   if {{G1__i}} > 0
+  on a au moins une occurrence
+#   endif
+# endfor

--- a/resources/skeleton/issue#14.skl
+++ b/resources/skeleton/issue#14.skl
@@ -1,0 +1,15 @@
+# skodgee
+    { 
+        "name": "Issue#14",
+        "description": "pas toujours de détail lors d'un plantage à la génération",
+        "author": "herve.heritier",
+        "version": "0.0.0",
+        "prefix": "#" 
+    }
+# end
+# declare
+    { "var": "diviseur", "ini":"2" }
+# end
+# defnum division 0
+# calc division 5 / {{diviseur}}
+5 / {{diviseur}} = {{__division}}

--- a/resources/skeleton/issue#15.skl
+++ b/resources/skeleton/issue#15.skl
@@ -1,0 +1,18 @@
+# skodgee
+    { 
+        "name": "Issue#14",
+        "description": "pas toujours de détail lors d'un plantage à la génération",
+        "author": "herve.heritier",
+        "version": "0.0.0",
+        "prefix": "#" 
+    }
+# end
+# declare
+    { "var": "variable", "ini":"2" }
+# end
+# defnum valeur 1
+# defstr chaine 1
+# calc valeur {{__valeur}} + {{variable}}
+valeur = {{__valeur}}
+# calc chaine {{__chaine}} + {{variable}}
+chaine = {{__chaine}}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -187,7 +187,13 @@ export async function activate(context: vscode.ExtensionContext) {
 								vscode.window.showErrorMessage(`La génération a échouée`)
 								panel.webview.postMessage({
 									command: 'resolveSkeletonOnError',
-									error: error.toString()
+									error: 
+										`plantage de la génération en ligne ${skeleton.nfoCurrentIndex+1}\n\n`+
+										`- détail de la ligne -------------------------------------------------\n`+
+										`${skeleton.nfoCurrentLine}\n`+
+										`----------------------------------------------------------------------\n\n`+
+										`- détail de l'erreur -------------------------------------------------\n`+
+										`${error.toString()}`
 								})
 							}
 						}


### PR DESCRIPTION
- Plus de plantage sur la directive if quand on tentait de tester la variable d'indice de la directive for qui la précédait
immédiatement alors que le groupe pointé par la directive for n'avait pas d'occurrence. (close #13)
- Tout plantage lors de la génération retourne désormais le numéro et le contenu de la ligne qui provoque l'erreur. (close #14)
- La directive `calc` est maintenant utilisable sur les variables de travail déclarée par la directive `defstr`. (close #15)