### PR TITLE
v0.0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [0.0.12] - 2021-05-13
+
+- Les groupes ne contenant pas de variables ne sont plus affichés dans le formulaire de saisie.
+- Dans une formulaire qui n'a pas été obtenue par analyse d'un document, un groupe répété contient maintenant
+son nombre minimum d'occurrence (zéro ou plus); ce n'était pas le cas avant, il y avait toujours
+au moins une occurrence affichée pour les groupes dont le nombre minimum était de zéro.
+
 ## [0.0.11] - 2021-05-12
 
 - Nouveaux contrôles de surface dans le formulaire avec les champs `min`, `max`, `step`, `type`, `pattern` pouvant être ajouté

--- a/README.md
+++ b/README.md
@@ -162,7 +162,9 @@ avec pour un objet groupe
 - `"cmp"` : tableau des objets qui composent le groupe. Peut contenir un mix d'objets variables et d'objets groupes sans limitation de profondeur
 - `"include"` : nom d'un fichier squelette qui pourra être appelé dans le corps du squelette avec la directive `include`
 
-Dans un même groupe on ne peut pas avoir à la fois les champs `"cmp"` et `"include"` au même niveau, mais dans un champ `"cmp"` on peut avoir des objets variables, des objets groupes avec champ `"cmp"` et des objets groupes avec champ `"include"`
+Dans un même groupe on ne peut pas avoir à la fois les champs `"cmp"` et `"include"` au même niveau,
+mais dans un champ `"cmp"` on peut avoir des objets variables, des objets groupes avec champ `"cmp"` et des objets groupes avec champ `"include"`.
+Les champs `"rpt"` et `"include"` ne peuvent pas non plus être présents au même niveau dans un groupe.
 
 ### Corps du squelette
 
@@ -376,14 +378,17 @@ sans le connaître. Ceci peut arriver si on fait appel par include à un squelet
 
 #### 🡆 Définition et utilisation de modèles
 
-La directive `model` permet de déclarer un ensemble de lignes réutilisables et de lui associer un nom pour pouvoir le rappeler avec la directive `usemodel`. La déclaration d'un ensemble se fait entre les directives `model` et  `endmodel`.
+La directive `model` permet de déclarer un ensemble de lignes réutilisables et de lui associer un nom pour pouvoir le rappeler avec la directive `usemodel`.
+La déclaration d'un ensemble se fait entre les directives `model` et  `endmodel`.
 
     # model nomDuModele
     ces lignes forment le 
     modèle nommé nomDuModele
     # endmodel
 
-Une directive `model` ne peut être imbriquée dans une autre directive `model`, mais elle peut être déclarée dans tout squelette, même dans un squelette appelé par la directive `include`. De plus, dans un modèle, on peut appeler un squelette, mais ni ce squelette, ni tout squelette inclu dans ce squelette ne peut déclarer un modèle puisque l'imbrication de modèle n'est pas autorisée.
+Une directive `model` ne peut être imbriquée dans une autre directive `model`, mais elle peut être déclarée dans tout squelette,
+même dans un squelette appelé par la directive `include`. De plus, dans un modèle, on peut appeler un squelette, mais ni ce squelette,
+ni tout squelette inclu dans ce squelette ne peut déclarer un modèle puisque l'imbrication de modèle n'est pas autorisée.
 
 Si une directive `model` associe un nom identique à une directive `model` précédente, alors elle la remplace.
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "SKODGEE",
   "description": "SKodgee Obviously Designed for Generation Enhanced Efficiently",
   "publisher": "skodgeeTeam",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "engines": {
     "vscode": "^1.46.0"
   },

--- a/resources/mocks/sample.js
+++ b/resources/mocks/sample.js
@@ -1,0 +1,17 @@
+/* sample1.js */
+
+var http = require('http');
+
+var myserver = http.createServer().listen(1337, '127.0.0.1');
+
+myserver.on('request',function(request,response) { 
+	response.writeHead(200, {'Content-Type': 'text/plain'});
+	var r = require('url').parse(request.url,true);
+    let data = { "name":"toto", "content":[
+        { "name":"ruba", "value":"rubrique A" },
+        { "name":"rubb", "value":"rubrique B" }
+    ]}
+	response.end(JSON.stringify(data));
+});
+
+console.log('Server running at http://127.0.0.1:1337/');

--- a/resources/page.html
+++ b/resources/page.html
@@ -12,6 +12,7 @@
             <button id="bouton">Charger le squelette</button><br/>
             <button id="generateCode" class="hidden">Générer le code</button>
             <button id="getCode" class="hidden">Récupérer le code généré</button>
+            <!--button id="mock">mock</button-->
         </div>
         <div id="table">
             <div id="formulaireContainer">

--- a/resources/page.js
+++ b/resources/page.js
@@ -66,6 +66,12 @@ document.querySelector('#generateCode').addEventListener('click',e=>{
     })
 })
 
+/*document.querySelector('#mock').addEventListener('click',e=>{
+    vscode.postMessage({
+        command:'mock'
+    })
+})*/
+
 document.querySelector('#getCode').addEventListener('click', e => {
     vscode.postMessage({command:'editGeneratedCodeInNewEditor',generatedCode:generatedCode})
 })
@@ -73,6 +79,9 @@ document.querySelector('#getCode').addEventListener('click', e => {
 window.addEventListener('message', e => {
     const message = e.data
     switch(message.command) {
+        /*case 'mock':
+            document.querySelector('#expansed').value = message.data
+            break*/
         case 'message':
             document.querySelector('#expansed').value = message.message
             break
@@ -260,6 +269,11 @@ generateInput = (e,parentName=undefined,value=undefined) => {
 }
 
 generateGroup = (e,parentName=undefined,values=undefined) => {
+
+    // ne pas créer de groupe vide (comme les includes sans variables)
+    if(e.cmp.length===0) return []
+    //
+    
     if(e.grp===undefined) return []
 
     let divGroup = document.createElement('div')

--- a/resources/skeleton/groupeTest.txt
+++ b/resources/skeleton/groupeTest.txt
@@ -1,0 +1,11 @@
+SKoDGee sample
+
+A = A
+B = B
+C = C
+
+group G1 contains 0 sub-group SG1
+
+
+000079002{"sn":"group.skl","dt":"2021-05-13T14:34:37.948Z","data":"'A':'A','G1[
+0]>B':'B','G1[0]>C':'C'"}                                                      

--- a/resources/skeleton/nestedInclude.skl
+++ b/resources/skeleton/nestedInclude.skl
@@ -1,6 +1,6 @@
 # skodgee
     { 
-        "name": "Include",
+        "name": "Nested Include",
         "description": "Squelette appelant des squelettes",
         "author": "herve.heritier",
         "version": "0.0.0",
@@ -9,8 +9,7 @@
 # end
 # declare
     { "grp":"premier", "include":"skeletonWithoutParameters.skl" },
-    { "grp":"second", "include":"variables.skl" },
-    { "grp":"troisieme", "include":"nestedInclude.skl" }
+    { "grp":"second", "include":"variables.skl" }
 # end
 Ci-dessous le contenu affichable d'un squelette appelé par include
 ------------------------------------------------------------------
@@ -19,8 +18,4 @@ Ci-dessous le contenu affichable d'un squelette appelé par include
 Un second contenu provenant d'un autre include
 ------------------------------------------------------------------
 # include {{second}}
-------------------------------------------------------------------
-Un troisième qui appelle un squelette appelant des squelettes ?
-------------------------------------------------------------------
-# include {{troisieme}}
 ------------------------------------------------------------------

--- a/src/complement.ts
+++ b/src/complement.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode'
 import * as path from 'path'
+import * as http from 'http'
 
 /**
  * Retourne le dernier élément du tableau pour lequel la fonction fournie est vraie
@@ -170,4 +171,23 @@ export function searchCircularReference(t:Array<any>):any {
         }
         return { found:false }
     }
+}
+
+/**
+ * Permet l'appel d'un service http
+ * @param request url du service
+ * @returns promesse retournant la réponse si ok, l'anomalie si ko
+ */
+export function service(request:any):Promise<any> {
+    return new Promise((resolve,reject)=>{
+        let data = ''
+        http.get(request,(res)=>{ 
+            if(res.statusCode!==200) {
+                reject(res)
+                res.resume()
+            }
+            res.on('data',c=>data+=c)
+            res.on('close',()=>resolve(data))
+        })
+    })
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -95,7 +95,8 @@ export async function activate(context: vscode.ExtensionContext) {
 							source: sourceAfterResolvedModels,
 							sourceBrut: resolvedValue.sourceBrut,
 							dictionnary: resolvedValue.dictionnary,
-							values: skeleton.extractValues(resolvedValue.dictionnary,[])				
+							//values: skeleton.extractValues(resolvedValue.dictionnary,[])				
+							values: skeleton.generateValuesFromDictionnary(resolvedValue.dictionnary)			
 						})
 					},(reason)=>{
 						throw reason
@@ -126,6 +127,19 @@ export async function activate(context: vscode.ExtensionContext) {
 		panel.webview.onDidReceiveMessage(
 			message=>{
 				switch(message.command) {
+					/*case 'mock':
+						complement.service('http://localhost:1337').then(resolve=>{
+							panel.webview.postMessage({
+								command:'mock',
+								data:resolve
+							})	
+						},reason=>{
+							panel.webview.postMessage({
+								command:'mock',
+								data:reason
+							})	
+						})
+						break*/
 					case 'loadSkeleton':
 						{
 							try {
@@ -136,6 +150,9 @@ export async function activate(context: vscode.ExtensionContext) {
 								skeleton.extendDictionnaryWithIncludes(value.location,value.name)
 								.then((resolvedValue)=>{
 									let source = resolvedValue.sourceLines.join('\n')
+									let values = message.values!==undefined 
+										? skeleton.extractValues(resolvedValue.dictionnary,message.values)
+										: skeleton.generateValuesFromDictionnary(resolvedValue.dictionnary)	
 									skeleton.resolveModels(source)
 									.then((sourceAfterResolvedModels)=>{
 										panel.webview.postMessage({
@@ -145,7 +162,7 @@ export async function activate(context: vscode.ExtensionContext) {
 											source: sourceAfterResolvedModels,
 											sourceBrut: resolvedValue.sourceBrut,
 											dictionnary: resolvedValue.dictionnary,
-											values: skeleton.extractValues(resolvedValue.dictionnary,message.values)
+											values: values
 										})
 									},(reason)=>{
 										panel.webview.postMessage({

--- a/src/skeleton.ts
+++ b/src/skeleton.ts
@@ -1143,3 +1143,27 @@ export async function resolveModels(skeletonSourceText:string) {
     })
     return resultLines.join('\n')
 }
+
+export function generateValuesFromDictionnary(dictionnary:dictionnary):any {
+    let values:any = []
+    dictionnary.forEach((d:variableObject|groupObject)=>{
+        if((d as variableObject).var!==undefined) {
+            if((d as variableObject).ini!==undefined) {
+                values.push((d as variableObject).ini)
+            }
+            else {
+                values.push((d as variableObject).var)
+            }
+        } else if((d as groupObject).grp!==undefined) {
+            let groups:any = []
+            let count = (d as groupObject).rpt===undefined ? 1 : parseInt((d as groupObject).rpt?.split(',')[0] as string)
+            let group = generateValuesFromDictionnary((d as groupObject).cmp)
+            while(count>0) {
+                groups.push(Array.from(group))
+                count--
+            }
+            values.push(groups)
+        }
+    })
+    return values
+}


### PR DESCRIPTION
- Les groupes ne contenant pas de variables ne sont plus affichés dans le formulaire de saisie. (close #8)
- Dans une formulaire qui n'a pas été obtenue par analyse d'un document, un groupe répété contient maintenant
son nombre minimum d'occurrence (zéro ou plus); ce n'était pas le cas avant, il y avait toujours
au moins une occurrence affichée pour les groupes dont le nombre minimum était de zéro.
